### PR TITLE
Make bg_enum mac compatible

### DIFF
--- a/scripts/bg_enum
+++ b/scripts/bg_enum
@@ -52,4 +52,4 @@ fi
 
 # print the log
 git log --color=always --oneline --decorate $BRANCH  -$NUM_ENTRIES | \
-  nl --number-format=ln -w 4 "-s: "
+  nl -n ln -w 4 "-s: "


### PR DESCRIPTION
There is no `--number-format` for mac version of `nl`, `-n` instead it has.